### PR TITLE
UMSMSA-47 : fix(eureka) - gradle 권한문제로 빌드 실패 -> sudo 명령어 제거

### DIFF
--- a/eureka-server/Jenkinsfile
+++ b/eureka-server/Jenkinsfile
@@ -36,7 +36,7 @@ pipeline {
         stage('Gradle Build') {
             steps {
                 dir('eureka-server') {
-                    sh 'sudo chmod +x gradlew'
+                    sh 'chmod +x gradlew'
                     sh './gradlew clean build '
                 }
             }


### PR DESCRIPTION
- 제목 : [UMSMSA-47 ] gradle 권한문제로 빌드 실패 -> sudo 명령어 제거
- 내용 :
	[작업 내용]
		1. jenkinsfile sudo 명령어 제거 (도커 컨테이너 안 sudo 명령어 안먹음0
		2. 
		3. 
	
	[체크 리스트]
		1. 문서 업데이트 : 해당없음
		2. 로컬 테스트 진행 : 진행완료
		3. 코드 리뷰 반영 : 해당없음
		4. 코드규약 준수 : 진행완료
		
	[관련이슈]
		- 이슈번호 : 
		- 이슈내용 : 
