### PR TITLE
UMSMSA-47 : fix(eureka) - gradle 외부 다운로드 실패

### DIFF
--- a/eureka-server/gradle/wrapper/gradle-wrapper.properties
+++ b/eureka-server/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+# distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=/var/jenkins_home/gradle/gradle-8.14.3-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
- 제목 : [UMSMSA-47]  gradle 외부 다운로드 실패
- 내용 :
	[작업 내용]
		1. 경로 지정
		2. 
		3. 
	
	[체크 리스트]
		1. 문서 업데이트 : 해당없음
		2. 로컬 테스트 진행 : 진행완료
		3. 코드 리뷰 반영 : 해당없음
		4. 코드규약 준수 : 진행완료
		
	[관련이슈]
		- 이슈번호 : 
		- 이슈내용 : 


[UMSMSA-47]: https://jang314.atlassian.net/browse/UMSMSA-47?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ